### PR TITLE
Fix bilibili live resolution

### DIFF
--- a/src/live/bilibili/bilibili.go
+++ b/src/live/bilibili/bilibili.go
@@ -99,7 +99,7 @@ func (l *Live) GetStreamUrls() (us []*url.URL, err error) {
 	}
 	body, err := http.Get(liveApiUrl, nil, map[string]string{
 		"cid":      l.realID,
-		"quality":  "0",
+		"quality":  "4",
 		"platform": "web",
 	})
 	if err != nil {


### PR DESCRIPTION
Missing 1080p resolution by default since bilibili updated API according to https://github.com/streamlink/streamlink/pull/2625